### PR TITLE
Created the frontend for exporting the attendee list and  ticket validation

### DIFF
--- a/frontend/src/pages/organizer/ToolsOrg/ToolsOrg.css
+++ b/frontend/src/pages/organizer/ToolsOrg/ToolsOrg.css
@@ -1,0 +1,84 @@
+.tools-container {
+  padding: 2rem;
+  background-color: #f9fafb;
+  min-height: 100vh;
+}
+
+.page-title {
+  text-align: left;
+  margin-left: 3rem;
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #1e293b;
+  opacity: 0;
+  transform: translateX(-40px);
+  transition: all 0.8s ease-in-out;
+}
+
+.page-title.visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.tool-section {
+  background: white;
+  border-radius: 1rem;
+  padding: 2rem;
+  margin: 2rem auto;
+  max-width: 600px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+
+.tool-section h2 {
+  margin-bottom: 0.5rem;
+}
+
+.tool-section select,
+.tool-section button {
+  margin-top: 1rem;
+  font-size: 1rem;
+}
+
+.tool-section select {
+  padding: 0.6rem 1.5rem 0.6rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  cursor: pointer;
+  margin-right: 1rem; 
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.3s, transform 0.2s;
+}
+
+button:hover {
+  transform: scale(1.03);
+}
+
+/* Gray before selection */
+.disabled-btn {
+  background-color: #d3d3d3;
+  color: #666;
+  cursor: not-allowed;
+}
+
+/* Blue after selection */
+.active-btn {
+  background-color: #0077ff;
+  color: white;
+}
+
+.active-btn:hover {
+  background-color: #005fcc;
+}
+
+.qr-result {
+  margin-top: 1rem;
+  color: green;
+  font-weight: bold;
+}

--- a/frontend/src/pages/organizer/ToolsOrg/ToolsOrg.jsx
+++ b/frontend/src/pages/organizer/ToolsOrg/ToolsOrg.jsx
@@ -1,11 +1,97 @@
+import React, { useState, useEffect } from "react";
 import "./ToolsOrg.css";
 
-const ToolsOrg = () => {
+export default function ToolsOrg() {
+  const events = [
+    { id: 1, name: "TED Talk" },
+    { id: 2, name: "Software Engineering Conference" },
+    { id: 3, name: "AI Evolving Technology" },
+  ];
+
+  const attendeeData = {
+    1: [
+      { name: "Alice Johnson", email: "alice@ted.com", ticketID: "TED001" },
+      { name: "Bob Smith", email: "bob@ted.com", ticketID: "TED002" },
+    ],
+    2: [
+      { name: "Catherine Lee", email: "catherine@sec.com", ticketID: "SEC001" },
+      { name: "Daniel Brown", email: "daniel@sec.com", ticketID: "SEC002" },
+      { name: "Emma White", email: "emma@sec.com", ticketID: "SEC003" },
+    ],
+    3: [
+      { name: "Frank Green", email: "frank@ai.com", ticketID: "AI001" },
+      { name: "Grace Kim", email: "grace@ai.com", ticketID: "AI002" },
+    ],
+  };
+
+  const [selectedEvent, setSelectedEvent] = useState("");
+  const [qrResult, setQrResult] = useState("");
+  const [titleVisible, setTitleVisible] = useState(false);
+
+  useEffect(() => {
+    // triggers animation after mount
+    setTimeout(() => setTitleVisible(true), 200);
+  }, []);
+
+  const handleEventChange = (e) => setSelectedEvent(e.target.value);
+
+  const handleExportCSV = () => {
+    if (!selectedEvent) return;
+    const attendees = attendeeData[selectedEvent];
+    const csvRows = [
+      ["Name", "Email", "Ticket ID"],
+      ...attendees.map((a) => [a.name, a.email, a.ticketID]),
+    ];
+    const csvContent = csvRows.map((r) => r.join(",")).join("\n");
+    const blob = new Blob([csvContent], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${
+      events.find((ev) => ev.id === parseInt(selectedEvent)).name
+    }_Attendees.csv`;
+    link.click();
+  };
+
+  const handleQRUpload = (event) => {
+    const file = event.target.files[0];
+    if (file) setQrResult(`✅ Ticket validated from: ${file.name}`);
+  };
+
   return (
-    <div className="toolsorg-page">
-      <h1>Tools</h1>
+    <div className="tools-container">
+      <h1 className={`page-title ${titleVisible ? "visible" : ""}`}>
+        Organizer Tools
+      </h1>
+
+      <section className="tool-section">
+        <h2>Export Attendee List</h2>
+        <p>Select an event to export its attendee list in CSV format.</p>
+
+        <select onChange={handleEventChange} value={selectedEvent}>
+          <option value=""> Select an event </option>
+          {events.map((event) => (
+            <option key={event.id} value={event.id}>
+              {event.name}
+            </option>
+          ))}
+        </select>
+
+        <button
+          onClick={handleExportCSV}
+          disabled={!selectedEvent}
+          className={selectedEvent ? "active-btn" : "disabled-btn"}
+        >
+          Export CSV
+        </button>
+      </section>
+
+      <section className="tool-section">
+        <h2>QR Ticket Validation</h2>
+        <p>Upload a QR code image to validate a ticket.</p>
+        <input type="file" accept="image/*" onChange={handleQRUpload} />
+        {qrResult && <p className="qr-result">{qrResult}</p>}
+      </section>
     </div>
   );
-};
-
-export default ToolsOrg;
+}


### PR DESCRIPTION
This pull request introduces the frontend implementation of the Organizer Tools page.
It provides two key features for event organizers:
1. Export Attendee List: Allows the organizer to select an event and export its attendee list as a CSV file.
2. Ticket Validation: Includes a QR upload section simulating ticket validation through file upload. 

Linked to issue #23 & issue #24 (both issues are implemented on the same page)
Note: 
- The event and attendee data are currently mocked for demonstration.
- QR code scanning is simulated through image upload
- Backend integration will be added later.
