### PR TITLE
Add and validate event location field and improve error styling

### DIFF
--- a/frontend/src/pages/organizer/EventCreation/EventCreation.css
+++ b/frontend/src/pages/organizer/EventCreation/EventCreation.css
@@ -1,17 +1,13 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
-.eventcreation-fullpage,
-.eventcreation-fullpage * {
+.ec-eventcreation-fullpage,
+.ec-eventcreation-fullpage * {
   box-sizing: border-box;
   font-family: 'Inter', sans-serif;
 }
 
-body {
-  margin: 0;
-  padding: 0;
-}
 
-.eventcreation-fullpage {
+.ec-eventcreation-fullpage {
   display: flex;
   width: 100%;
   gap: 2rem;
@@ -19,7 +15,7 @@ body {
   background: #f5f5f5;
 }
 
-.eventcreation-left {
+.ec-eventcreation-left {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -27,11 +23,11 @@ body {
   height: auto;
 }
 
-.eventcreation-right {
+.ec-eventcreation-right {
   flex: 1;
 }
 
-.event-form-card {
+.ec-event-form-card {
   background: #ffffff;
   padding: 2rem;
   border-radius: 16px;
@@ -41,22 +37,22 @@ body {
   height: auto !important;
 }
 
-.form-group {
+.ec-form-group {
   display: flex;
   flex-direction: column;
   margin-bottom: 1.2rem;
   position: relative;  
 }
 
-.form-group label {
+.ec-form-group label {
   font-weight: 600;
   margin-bottom: 0.4rem;
   color: rgb(40, 9, 9);
 }
 
-.form-group input,
-.form-group textarea,
-.form-group select {
+.ec-form-group input,
+.ec-form-group textarea,
+.ec-form-group select {
   padding: 0.9rem;
   background: #fafafa;
   border: 1px solid #e0e0e0;
@@ -65,17 +61,17 @@ body {
 }
 
 /* ROW OF FIELDS */
-.form-row {
+.ec-form-row {
   display: flex;
   gap: 1rem;
 }
 
-.form-row .form-group {
+.ec-form-row .ec-form-group {
   flex: 1;
 }
 
 /* SUBMIT BUTTON */
-.submit-button {
+.ec-submit-button {
   width: 100%;
   padding: 1rem;
   background: #643f42;
@@ -86,19 +82,19 @@ body {
   cursor: pointer;
 }
 
-.submit-button:hover {
+.ec-submit-button:hover {
   background: #702d2d;
 }
 
 /* EVENT LIST */
-.event-list {
+.ec-event-list {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
 /* EVENT CARD */
-.event-card {
+.ec-event-card {
   background: #fff;
   padding: 1.2rem;
   border-radius: 12px;
@@ -107,13 +103,13 @@ body {
 
 /* MOBILE */
 @media (max-width: 900px) {
-  .eventcreation-fullpage {
+  .ec-eventcreation-fullpage {
     flex-direction: column;
   }
 }
 
 /* DROPDOWN */
-.dropdown-location {
+.ec-dropdown-location {
   position: absolute;
   top: 100%;
   left: 0;
@@ -128,7 +124,7 @@ body {
   box-shadow: 0 4px 10px rgba(0,0,0,0.1);
 }
 
-.dropdown-item {
+.ec-dropdown-item {
   padding: 10px;
   font-size: 0.9rem;
   cursor: pointer;
@@ -136,22 +132,22 @@ body {
   word-break: break-word;
 }
 
-.dropdown-item:hover {
+.ec-dropdown-item:hover {
   background: #f0f0f0;
 }
 
 /* TEXTAREA COUNTER */
-.textarea-container {
+.ec-textarea-container {
   position: relative;
 }
 
-.textarea-container textarea {
+.ec-textarea-container textarea {
   width: 100%;
   padding-bottom: 28px;
   box-sizing: border-box;
 }
 
-.char-counter-inside {
+.ec-char-counter-inside {
   position: absolute;
   bottom: 6px;
   right: 12px;
@@ -161,39 +157,39 @@ body {
 }
 
 /* ERROR STATES */
-.input-error {
+.ec-input-error {
   border: 2px solid #ff3b3b !important;
   background: #ffecec !important;
 }
 
-.error-text {
+.ec-error-text {
   color: #ff3b3b;
   font-size: 0.8rem;
   margin-top: 4px;
   padding-left: 2px;
 }
 
-.event-buttons {
+.ec-event-buttons {
   display: flex;
   gap: 0.8rem;   
   margin-top: 1rem;
 }
 
-.edit-btn {
+.ec-edit-btn {
   padding: 0.6rem 1rem;
   background: #ebeaea;      
   color: #3e4551;           
-  border: 1px solid #a8b6cf;
+  border: 1px solid #a5a7ac;
   border-radius: 8px;
   cursor: pointer;
   font-weight: 600;
 }
 
-.edit-btn:hover {
-  background: #e3e3e4;
+.ec-edit-btn:hover {
+  background: #cfcfd2;
 }
 
-.delete-btn {
+.ec-delete-btn {
   padding: 0.6rem 1rem;
   background: #ffe8e8;      
   color: #d60000;            
@@ -203,6 +199,6 @@ body {
   font-weight: 600;
 }
 
-.delete-btn:hover {
+.ec-delete-btn:hover {
   background: #ffd0d0;
 }

--- a/frontend/src/pages/organizer/EventCreation/EventCreation.jsx
+++ b/frontend/src/pages/organizer/EventCreation/EventCreation.jsx
@@ -334,80 +334,80 @@ const EventCreation = () => {
   // RETURN UI
   // ========================================
   return (
-    <div className="eventcreation-fullpage">
-      <div className="event-form-card">
+    <div className="ec-eventcreation-fullpage">
+      <div className="ec-event-form-card">
         <h1>Create Event</h1>
 
         {/* EVENT TITLE */}
-        <div className="form-group">
+        <div className="ec-form-group">
           <label>Event Name</label>
           <input
             type="text"
             name="eventTitle"
             value={formData.eventTitle}
             onChange={handleChange}
-            className={errors.eventTitle ? "input-error" : ""}
+            className={errors.eventTitle ? "ec-input-error" : ""}
           />
           {errors.eventTitle && (
-            <div className="error-text">{errors.eventTitle}</div>
+            <div className="ec-error-text">{errors.eventTitle}</div>
           )}
         </div>
 
         {/* DESCRIPTION */}
-        <div className="form-group textarea-wrapper">
+        <div className="ec-form-group textarea-wrapper">
           <label>Description</label>
-          <div className="textarea-container">
+          <div className="ec-textarea-container">
             <textarea
               name="eventDescription"
               value={formData.eventDescription}
               onChange={handleChange}
               maxLength={250}
-              className={errors.eventDescription ? "input-error" : ""}
+              className={errors.eventDescription ? "ec-input-error" : ""}
             />
-            <span className="char-counter-inside">
+            <span className="ec-char-counter-inside">
               {formData.eventDescription.length}/250
             </span>
           </div>
           {errors.eventDescription && (
-            <div className="error-text">{errors.eventDescription}</div>
+            <div className="ec-error-text">{errors.eventDescription}</div>
           )}
         </div>
 
         {/* DATE / TIME / DURATION */}
-        <div className="form-row">
+        <div className="ec-form-row">
           {/* DATE */}
-          <div className="form-group">
+          <div className="ec-form-group">
             <label>Date</label>
             <input
               type="date"
               name="eventDate"
               value={formData.eventDate}
               onChange={handleChange}
-              className={errors.eventDate ? "input-error" : ""}
+              className={errors.eventDate ? "ec-input-error" : ""}
               min={new Date().toISOString().split("T")[0]}   // <— THIS LINE
             />
             {errors.eventDate && (
-              <div className="error-text">{errors.eventDate}</div>
+              <div className="ec-error-text">{errors.eventDate}</div>
             )}
           </div>
 
           {/* TIME */}
-          <div className="form-group">
+          <div className="ec-form-group">
             <label>Time</label>
             <input
               type="time"
               name="eventTime"
               value={formData.eventTime}
               onChange={handleChange}
-              className={errors.eventTime ? "input-error" : ""}
+              className={errors.eventTime ? "ec-input-error" : ""}
             />
             {errors.eventTime && (
-              <div className="error-text">{errors.eventTime}</div>
+              <div className="ec-error-text">{errors.eventTime}</div>
             )}
           </div>
 
           {/* DURATION */}
-          <div className="form-group">
+          <div className="ec-form-group">
             <label>Duration (hours)</label>
             <input
               type="number"
@@ -416,34 +416,34 @@ const EventCreation = () => {
               name="eventDuration"
               value={formData.eventDuration}
               onChange={handleChange}
-              className={errors.eventDuration ? "input-error" : ""}
+              className={errors.eventDuration ? "ec-input-error" : ""}
             />
             {errors.eventDuration && (
-              <div className="error-text">{errors.eventDuration}</div>
+              <div className="ec-error-text">{errors.eventDuration}</div>
             )}
           </div>
         </div>
 
         {/* LOCATION */}
-        <div className="form-group">
+        <div className="ec-form-group">
           <label>Location</label>
           <input
             type="text"
             value={locationQuery}
             onChange={handleLocationChange}
-            className={errors.eventLocation ? "input-error" : ""}
+            className={errors.eventLocation ? "ec-input-error" : ""}
             autoComplete="off"
           />
           {errors.eventLocation && (
-            <div className="error-text">{errors.eventLocation}</div>
+            <div className="ec-error-text">{errors.eventLocation}</div>
           )}
 
           {locationResults.length > 0 && (
-            <div ref={dropdownRef} className="dropdown-location">
+            <div ref={dropdownRef} className="ec-dropdown-location">
               {locationResults.map((loc) => (
                 <div
                   key={loc.place_id}
-                  className="dropdown-item"
+                  className="ec-dropdown-item"
                   onClick={() => selectLocation(loc)}
                 >
                   {loc.display_name}
@@ -454,37 +454,37 @@ const EventCreation = () => {
         </div>
 
         {/* CATEGORY */}
-        <div className="form-group">
+        <div className="ec-form-group">
           <label>Category</label>
           <input
             type="text"
             name="eventCategory"
             value={formData.eventCategory}
             onChange={handleChange}
-            className={errors.eventCategory ? "input-error" : ""}
+            className={errors.eventCategory ? "ec-input-error" : ""}
           />
           {errors.eventCategory && (
-            <div className="error-text">{errors.eventCategory}</div>
+            <div className="ec-error-text">{errors.eventCategory}</div>
           )}
         </div>
 
         {/* ORGANIZATION */}
-        <div className="form-group">
+        <div className="ec-form-group">
           <label>Organization</label>
           <input
             type="text"
             name="eventOrganization"
             value={formData.eventOrganization}
             onChange={handleChange}
-            className={errors.eventOrganization ? "input-error" : ""}
+            className={errors.eventOrganization ? "ec-input-error" : ""}
           />
           {errors.eventOrganization && (
-            <div className="error-text">{errors.eventOrganization}</div>
+            <div className="ec-error-text">{errors.eventOrganization}</div>
           )}
         </div>
 
         {/* CAPACITY */}
-        <div className="form-group">
+        <div className="ec-form-group">
           <label>Capacity</label>
           <input
             type="number"
@@ -492,33 +492,33 @@ const EventCreation = () => {
             name="eventCapacity"
             value={formData.eventCapacity}
             onChange={handleChange}
-            className={errors.eventCapacity ? "input-error" : ""}
+            className={errors.eventCapacity ? "ec-input-error" : ""}
           />
           {errors.eventCapacity && (
-            <div className="error-text">{errors.eventCapacity}</div>
+            <div className="ec-error-text">{errors.eventCapacity}</div>
           )}
         </div>
 
         {/* TICKET TYPE */}
-        <div className="form-group">
+        <div className="ec-form-group">
           <label>Ticket Type</label>
           <select
             name="ticketType"
             value={formData.ticketType}
             onChange={handleChange}
-            className={errors.ticketType ? "input-error" : ""}
+            className={errors.ticketType ? "ec-input-error" : ""}
           >
             <option value="free">Free</option>
             <option value="paid">Paid</option>
           </select>
           {errors.ticketType && (
-            <div className="error-text">{errors.ticketType}</div>
+            <div className="ec-error-text">{errors.ticketType}</div>
           )}
         </div>
 
         {/* PRICE (PAID ONLY) */}
         {formData.ticketType === "paid" && (
-          <div className="form-group">
+          <div className="ec-form-group">
             <label>Ticket Price (CAD)</label>
             <input
               type="number"
@@ -527,25 +527,25 @@ const EventCreation = () => {
               name="price"
               value={formData.price}
               onChange={handleChange}
-              className={errors.price ? "input-error" : ""}
+              className={errors.price ? "ec-input-error" : ""}
             />
             {errors.price && (
-              <div className="error-text">{errors.price}</div>
+              <div className="ec-error-text">{errors.price}</div>
             )}
           </div>
         )}
 
         {/* BUTTON */}
-        <button className="submit-button" onClick={handleSubmit}>
+        <button className="ec-submit-button" onClick={handleSubmit}>
           {editEventId ? "Update Event" : "Create Event"}
         </button>
       </div>
 
       {/* RIGHT SIDE */}
-      <div className="eventcreation-right">
+      <div className="ec-eventcreation-right">
         <h2>Your Events</h2>
 
-        <div className="event-list">
+        <div className="ec-event-list">
           {userEvents.length === 0 ? (
             <p>No events created yet.</p>
           ) : (
@@ -553,7 +553,7 @@ const EventCreation = () => {
               const date = new Date(event.eventDate.seconds * 1000);
 
               return (
-                <div key={event.id} className="event-card">
+                <div key={event.id} className="ec-event-card">
                   <h3>{event.eventTitle}</h3>
                   <p>{event.eventDescription}</p>
                   <p>
@@ -563,11 +563,11 @@ const EventCreation = () => {
                     <strong>Location:</strong> {event.eventLocation}
                   </p>
 
-                  <div className="event-buttons">
-                    <button className="edit-btn" onClick={() => handleEdit(event)}>
+                  <div className="ec-event-buttons">
+                    <button className="ec-edit-btn" onClick={() => handleEdit(event)}>
                       Edit
                     </button>
-                    <button className="delete-btn" onClick={() => handleDelete(event.id)}>
+                    <button className="ec-delete-btn" onClick={() => handleDelete(event.id)}>
                       Delete
                     </button>
                   </div>


### PR DESCRIPTION
 This PR adds a fully validated event location field to the Event Creation page. Users must select a location from the autocomplete dropdown (Québec-restricted), enabling accurate map representation of events across the platform. linked to issue #92. 

details:
- Added mandatory location input with autocomplete dropdown
- Limited search results to Québec for relevance + speed
- Implemented click-outside dropdown dismissal
- Added strict validation: users must pick a value only from dropdown
- Added red highlight + inline error text for invalid/missing fields
- UI polish: improved error text size & color
